### PR TITLE
Drafting `with` type remapping support for Rust

### DIFF
--- a/crates/guest-rust/src/lib.rs
+++ b/crates/guest-rust/src/lib.rs
@@ -674,19 +674,25 @@
 ///     // has generated bindings for all WASI types and structures. In this
 ///     // situation the key `with` here can be used to use those types
 ///     // elsewhere rather than regenerating types.
+///     // If for example your world refers to some type and you want to use
+///     // your own custom implementation of that type then you can specify
+///     // that here as well. There is a requirement on the remapped (custom)
+///     // type to have the same internal structure and identical to what would
+///     // wit-bindgen generate (including alignment, etc.), since
+///     // lifting/lowering uses its fields directly.
 ///     //
-///     // The `with` key here only works for interfaces referred to by imported
-///     // functions. Additionally it only supports replacing types at the
-///     // interface level at this time.
+///     // The `with` key here works for interfaces and individual types.
 ///     //
-///     // When an interface is specified here no bindings will be generated at
-///     // all. It's assumed bindings are fully generated upstream. This is an
-///     // indicator that any further references to types defined in these
-///     // interfaces should use the upstream paths specified here instead.
+///     // When an interface or type is specified here no bindings will be
+///     // generated at all. It's assumed bindings are fully generated
+///     // upstream. This is an indicator that any further references to types
+///     // defined in these interfaces should use the upstream paths specified
+///     // here instead.
 ///     //
 ///     // Any unused keys in this map are considered an error.
 ///     with: {
 ///         "wasi:io/poll": wasi::io::poll,
+///         "my:package/foo/my-type": types::MyType,
 ///     },
 ///
 ///     // An optional list of function names to skip generating bindings for.

--- a/crates/rust/src/interface.rs
+++ b/crates/rust/src/interface.rs
@@ -1,7 +1,7 @@
 use crate::bindgen::FunctionBindgen;
 use crate::{
-    int_repr, to_rust_ident, to_upper_camel_case, wasm_type, FnSig, Identifier, InterfaceName,
-    Ownership, RuntimeItem, RustFlagsRepr, RustWasm,
+    full_wit_type_name, int_repr, to_rust_ident, to_upper_camel_case, wasm_type, FnSig, Identifier,
+    InterfaceName, Ownership, RuntimeItem, RustFlagsRepr, RustWasm,
 };
 use anyhow::Result;
 use heck::*;
@@ -1138,14 +1138,21 @@ macro_rules! {macro_name} {{
     }
 
     pub fn type_path(&self, id: TypeId, owned: bool) -> String {
-        self.type_path_with_name(
-            id,
-            if owned {
-                self.result_name(id)
-            } else {
-                self.param_name(id)
-            },
-        )
+        let full_wit_type_name = full_wit_type_name(self.resolve, id);
+        if let Some(remapped_path) = self.gen.with.get(&full_wit_type_name) {
+            let mut path_to_root = self.path_to_root();
+            path_to_root.push_str(remapped_path);
+            path_to_root
+        } else {
+            self.type_path_with_name(
+                id,
+                if owned {
+                    self.result_name(id)
+                } else {
+                    self.param_name(id)
+                },
+            )
+        }
     }
 
     fn type_path_with_name(&self, id: TypeId, name: String) -> String {

--- a/crates/rust/tests/codegen.rs
+++ b/crates/rust/tests/codegen.rs
@@ -486,3 +486,124 @@ mod generate_unused_types {
         generate_unused_types: true,
     });
 }
+
+mod with_type {
+
+    mod my_types {
+        #[derive(Debug, Clone, Copy)]
+        pub struct MyA {
+            pub inner: f64,
+        }
+
+        #[derive(Debug, Clone, Copy)]
+        pub struct MyB;
+
+        impl MyB {
+            pub fn take_handle(&self) -> u32 {
+                0
+            }
+
+            pub fn from_handle(handle: u32) -> Self {
+                Self
+            }
+        }
+
+        pub enum MyC {
+            A(MyA),
+            B(MyB),
+        }
+
+        pub struct MyD {
+            pub inner: u32,
+        }
+
+        pub struct MyE {
+            pub inner: u32,
+        }
+    }
+
+    wit_bindgen::generate!({
+        inline: "
+            package my:inline;
+
+            interface foo {
+
+                record a {
+                    inner: f64,
+                }
+
+                resource b;
+
+                variant c {
+                    a(a),
+                    b(b),
+                }
+
+                func1: func(v: a) -> a;
+                func2: func(v: b) -> b;
+                func3: func(v: list<a>) -> list<b>;
+                func4: func(v: option<a>) -> option<a>;
+                func5: func() -> result<a>;
+            }
+
+            interface bar {
+                record e {
+                    inner: u32,
+                }
+
+                func6: func(v: e) -> e;
+            }
+
+            world dummy-type-remap {
+                // test remapping with importing type directly 
+                use foo.{c};
+                import func7: func(v: c) -> c;
+
+                // test remapping the type defined in world
+                record d {
+                    inner: u32,
+                }
+
+                import func8: func(v: d) -> d;
+
+                export bar;
+            }
+        ",
+        with: {
+            "my:inline/foo/a": my_types::MyA,
+            "my:inline/foo/b": my_types::MyB,
+            "my:inline/foo/c": my_types::MyC,
+            "dummy-type-remap/d": my_types::MyD,
+            "my:inline/bar/e": my_types::MyE,
+        },
+    });
+
+    pub struct Guest;
+
+    impl exports::my::inline::bar::Guest for Guest {
+        fn func6(v: my_types::MyE) -> my_types::MyE {
+            v
+        }
+    }
+
+    fn test() {
+        let a = my_types::MyA { inner: 0.0 };
+        let _ = my::inline::foo::func1(a);
+
+        let b = my_types::MyB;
+        let _ = my::inline::foo::func2(b);
+
+        let c = my_types::MyC::A(a);
+        let _ = func7(c);
+
+        let a_list = vec![a, a];
+        let _ = my::inline::foo::func3(&a_list);
+
+        let _ = my::inline::foo::func4(Some(a));
+
+        let _ = my::inline::foo::func5();
+
+        let d = my_types::MyD { inner: 0 };
+        let _ = func8(d);
+    }
+}


### PR DESCRIPTION
This PR is intended for discussing the changes before proposing them to the upstream. After this PR is approved and merged, I'll make the following issue and PR to the upstream with the following PR description:
==========================================================

Issue
==========================================================

Add individual type remapping in the `with` parameter of the `wit_bindgen::generate` macro

### Motivation
To provide a way to use your own types instead of the defined in WIT in the generated bindings. For example to implement a specific type constructors, methods, arithmetic operations, etc. for the types defined in the WIT interface.

### Implementation

I opened a PR with a suggested implementation. See the PR description for the details.

PR
==========================================================

Add individual type remapping in the `with` parameter of the `wit_bindgen::generate` macro

The type remapping happens in the `InterfaceGenerator::type_path` only for the types provided via `with` macros parameter. Effectively, the remapped type are used in place of the original type everywhere in the generated bindings for any imports and exports, including lifting and lowering functions. The original type definition is not generated. 
This approach puts a requirement on the remapped type to have the same internal structure and identical to what would `wit-bindgen` generate (including alignment, etc.), since lifting/lowering uses its fields directly.
See the `codegen::with_type` test for the example of the remapping in action for various types.
